### PR TITLE
Make the CURL dependency optional, through a CMake Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ set (PB_PRODUCT_NAME "Planet Blupi")
 set (PB_PACKAGE_NAME "planetblupi")
 set (PB_DESCRIPTION "Planet Blupi - A delerious spell-binding game")
 
+option(PLANETBLUPI_HTTP_VERSION_CHECK "Run a version check over HTTP (with CURL)" OFF)
+
 configure_file (
   "${PROJECT_SOURCE_DIR}/src/config.h.in"
   "${PROJECT_BINARY_DIR}/include/config.h"
@@ -115,7 +117,10 @@ find_package (PkgConfig REQUIRED)
 pkg_search_module (SDL2 REQUIRED sdl2)
 pkg_search_module (SDL2_MIXER REQUIRED SDL2_mixer)
 pkg_search_module (SDL2_IMAGE REQUIRED SDL2_image)
-pkg_search_module (CURL REQUIRED libcurl)
+if(${PLANETBLUPI_HTTP_VERSION_CHECK})
+  pkg_search_module (CURL REQUIRED libcurl)
+  add_definitions(-DUSE_CURL)
+endif()
 
 if ("${STATIC_BUILD}")
   pkg_search_module (PNG REQUIRED libpng)
@@ -131,7 +136,9 @@ if ("${STATIC_BUILD}")
     pkg_search_module (PULSE REQUIRED libpulse)
   endif ()
 
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB")
+  if(${PLANETBLUPI_HTTP_VERSION_CHECK})
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCURL_STATICLIB")
+  endif ()
 endif ()
 
 ###########################
@@ -147,7 +154,6 @@ if ("${STATIC_BUILD}")
     ${SDL2_STATIC_LIBRARIES}
     ${SDL2_MIXER_STATIC_LIBRARIES}
     ${SDL2_IMAGE_STATIC_LIBRARIES}
-    ${CURL_STATIC_LIBRARIES}
     ${SDLKitchensink_STATIC_LIBRARIES}
     ${PNG_STATIC_LIBRARIES}
     ${AVCODEC_STATIC_LIBRARIES}
@@ -156,6 +162,13 @@ if ("${STATIC_BUILD}")
     ${SWSCALE_STATIC_LIBRARIES}
     ${SWRESAMPLE_STATIC_LIBRARIES}
   )
+
+  if(${PLANETBLUPI_HTTP_VERSION_CHECK})
+    set (planetblupi_DEPS
+      ${planetblupi_DEPS}
+      ${CURL_STATIC_LIBRARIES}
+    )
+  endif ()
 
   if (UNIX AND NOT APPLE)
     list (APPEND planetblupi_DEPS
@@ -173,6 +186,13 @@ else ()
     ${SDLKitchensink_LIBRARIES}
     pthread
   )
+
+  if(${PLANETBLUPI_HTTP_VERSION_CHECK})
+    set (planetblupi_DEPS
+      ${planetblupi_DEPS}
+      ${CURL_LIBRARIES}
+    )
+  endif ()
 endif ()
 
 target_link_libraries (planetblupi PUBLIC ${planetblupi_DEPS})

--- a/src/blupi.cxx
+++ b/src/blupi.cxx
@@ -30,7 +30,9 @@
 
 #include <SDL2/SDL_image.h>
 #include <argagg/argagg.hpp>
-#include <curl/curl.h>
+#ifdef USE_CURL
+  #include <curl/curl.h>
+#endif
 
 #include "json/json.hpp"
 
@@ -81,11 +83,13 @@ bool        g_bTermInit = false; // initialisation en cours
 Uint32      g_lastPhase = 999;
 static bool g_pause;
 
+#ifdef USE_CURL
 struct url_data {
   CURLcode status;
   char *   buffer;
   size_t   size;
 };
+#endif
 
 template <typename Out>
 static void
@@ -462,6 +466,7 @@ static size_t
 updateCallback (void * ptr, size_t size, size_t nmemb, void * data)
 {
   size_t     realsize = size * nmemb;
+#ifdef USE_CURL
   url_data * mem      = static_cast<url_data *> (data);
 
   mem->buffer =
@@ -472,6 +477,7 @@ updateCallback (void * ptr, size_t size, size_t nmemb, void * data)
     mem->size += realsize;
     mem->buffer[mem->size] = 0;
   }
+#endif
 
   return realsize;
 }
@@ -479,6 +485,7 @@ updateCallback (void * ptr, size_t size, size_t nmemb, void * data)
 static void
 CheckForUpdates ()
 {
+#ifdef USE_CURL
   url_data chunk;
 
   chunk.buffer = nullptr; /* we expect realloc(NULL, size) to work */
@@ -515,6 +522,7 @@ CheckForUpdates ()
     free (chunk.buffer);
 
   curl_easy_cleanup (curl);
+#endif
 }
 
 static int


### PR DESCRIPTION
Here's a proposal to disable the version-check "call-home" funtionality by putting everything CURL-related behind a CMake option.

It works as far as I can see, but I appreciate your scrutiny.